### PR TITLE
Add basic support for refreshing of content without removing the content view

### DIFF
--- a/PJFDataSource/PJFContentWrapperView.h
+++ b/PJFDataSource/PJFContentWrapperView.h
@@ -34,10 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol PJFContentWrapperViewDelegate <NSObject>
 @optional
+- (void)contentWrapperView:(PJFContentWrapperView *)wrapperView willShowLoadingView:(UIView *)loadingView;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView willShowNoContentView:(PJFImageTitleMessageView *)placeholderView;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView willShowErrorView:(PJFImageTitleMessageView *)placeholderView withError:(NSError *)error;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView willShowContentView:(UIView *)contentView;
 
+- (void)contentWrapperView:(PJFContentWrapperView *)wrapperView didShowLoadingView:(UIView *)loadingView;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView didShowNoContentView:(PJFImageTitleMessageView *)placeholderView;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView didShowErrorView:(PJFImageTitleMessageView *)placeholderView;
 - (void)contentWrapperView:(PJFContentWrapperView *)wrapperView didShowContentView:(UIView *)contentView;

--- a/PJFDataSource/PJFContentWrapperView.m
+++ b/PJFDataSource/PJFContentWrapperView.m
@@ -71,8 +71,16 @@
         return;
     }
     
+    if ([self.delegate respondsToSelector:@selector(contentWrapperView:willShowLoadingView:)]) {
+        [self.delegate contentWrapperView:self willShowLoadingView:loadingView];
+    }
+    
     [self _showOnlySubview:loadingView animated:YES];
     [loadingView startAnimating];
+    
+    if ([self.delegate respondsToSelector:@selector(contentWrapperView:didShowLoadingView:)]) {
+        [self.delegate contentWrapperView:self didShowLoadingView:loadingView];
+    }
 }
 
 - (void)showNoContentPlaceholderView;

--- a/PJFDataSource/PJFLoadingCoordinator.h
+++ b/PJFDataSource/PJFLoadingCoordinator.h
@@ -28,6 +28,7 @@ typedef void (^PJFLoadingBlock)(PJFLoadingState *loadingState);
 - (instancetype)initWithDataSource:(nullable PJFDataSource *)dataSource NS_DESIGNATED_INITIALIZER;
 
 - (void)loadContentWithBlock:(PJFLoadingBlock)block;
+- (void)loadContentWithBlock:(PJFLoadingBlock)block allowingContentViewToRemain:(BOOL)allowContentViewToRemain;
 - (void)loadContentDidFinishWithError:(nullable NSError *)error;
 
 @end

--- a/PJFDataSource/PJFLoadingCoordinator.m
+++ b/PJFDataSource/PJFLoadingCoordinator.m
@@ -45,6 +45,11 @@
 
 - (void)loadContentWithBlock:(PJFLoadingBlock)block;
 {
+    [self loadContentWithBlock:block allowingContentViewToRemain:NO];
+}
+
+- (void)loadContentWithBlock:(PJFLoadingBlock)block allowingContentViewToRemain:(BOOL)allowContentViewToRemain;
+{
     [self.loadingState invalidate];
     self.loadingState = [PJFLoadingState new];
     self.loadingState.valid = YES;
@@ -53,7 +58,11 @@
         [self.dataSource.delegate dataSourceWillBeginLoading:self.dataSource];
     }
     
-    [[self _contentWrapperView] showLoadingPlaceholderView];
+    BOOL showingContentView = [[self _contentWrapperView] isShowingContentView];
+    
+    if (!showingContentView || !allowContentViewToRemain) {
+        [[self _contentWrapperView] showLoadingPlaceholderView];
+    }
     
     if (block) {
         block(self.loadingState);

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ We want to keep PJFDataSource simple, but there are some things we know we'd lik
 
 * Increased customizability of PJFImageTitleMessageView via the `UIAppearance` protocol
 * Customization of the animation (currently a rotation) applied to the PJFLoadingView's loading image 
-* Support for "reloading", where the current content view remains visible while the data source refreshes its content
 
 If you'd like to help, see "Contributing" below.
 


### PR DESCRIPTION
This is primarily intended to support 'pull to refresh' type of behavior, where you trigger a reload of the data source, but leave the currently-loaded content view in place.

Also added PJFContentWrapperViewDelegate support for `will/didShowLoadingView`.