### PR TITLE
Version 1.0.4.

### DIFF
--- a/PJFDataSource.podspec
+++ b/PJFDataSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'PJFDataSource'
-  s.version  = '1.0.3'
+  s.version  = '1.0.4'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A small library that provides a simple, clean architecture for your app to manage its data sources & common content view states.'
   s.homepage = 'https://github.com/square/PJFDataSource'

--- a/PJFDataSource/PJFDataSource.h
+++ b/PJFDataSource/PJFDataSource.h
@@ -20,14 +20,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PJFDataSource : NSObject
 
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDelegate:(id <PJFDataSourceDelegate>)delegate NS_DESIGNATED_INITIALIZER;
+- (instancetype)init;
+- (instancetype)initWithDelegate:(id <PJFDataSourceDelegate>)delegate;
 
 - (void)loadContent;
 
 - (BOOL)hasContent;
 
-@property (nonatomic, readonly, weak, nullable) id <PJFDataSourceDelegate> delegate;
+@property (nonatomic, weak, nullable) id <PJFDataSourceDelegate> delegate;
 @property (nonatomic, readonly) PJFLoadingCoordinator *loadingCoordinator;
 
 @end


### PR DESCRIPTION
Made `init` available to use to improve Swift compatibility, being able to initialize without the delegate.